### PR TITLE
Store text with emojis using unicode escape.

### DIFF
--- a/ainft/__init__.py
+++ b/ainft/__init__.py
@@ -8,6 +8,7 @@ from .types import (
     ThreadTransactionResult,
     MessageTransactionResult,
 )
+from .utils import truncate_text
 
 __all__ = [
     "Ainft",
@@ -16,4 +17,5 @@ __all__ = [
     "TransactionResult",
     "ThreadTransactionResult",
     "MessageTransactionResult",
+    "truncate_text",
 ]

--- a/ainft/chat/messages.py
+++ b/ainft/chat/messages.py
@@ -16,8 +16,6 @@ from ..utils import *
 
 
 class Messages:
-    _max_content_length = 200
-
     def __init__(self, ain: Ain):
         self._ain = ain
 
@@ -43,14 +41,12 @@ class Messages:
 
         await self._validate(app_id, token_id, user_addr, messages)
 
-        return await self._send_tx_for_store_message(
-            **dict(
-                messages=messages,
-                app_id=app_id,
-                token_id=token_id,
-                address=user_addr,
-            )
-        )
+        return await self._send_tx_for_store_message(**dict(
+            messages=messages,
+            app_id=app_id,
+            token_id=token_id,
+            address=user_addr,
+        ))
 
     async def _validate(
         self, app_id: str, token_id: str, address: str, messages: List[Message]
@@ -81,10 +77,9 @@ class Messages:
         address: str,
         timestamp: int,
     ) -> TransactionInput:
-        op_list = []
+        ops = []
         for msg in messages:
-            msg_key = str(msg.created_at)
-            msg_path = join_paths(
+            path = join_paths(
                 [
                     "apps",
                     app_id,
@@ -97,20 +92,21 @@ class Messages:
                     "threads",
                     msg.thread_id,
                     "messages",
-                    msg_key,
+                    str(msg.created_at),
                 ]
             )
-            trimmed_content = msg.content[: self._max_content_length]
+            content = truncate_text(msg.content, 200)
+            content = content.encode("unicode-escape").decode("ASCII")
             message = {
                 "id": msg.id,
                 "role": msg.role,
-                "content": trimmed_content,
+                "content": content,
                 **({"metadata": msg.metadata} if msg.metadata else {}),
             }
-            op = SetOperation(type="SET_VALUE", ref=msg_path, value=message)
-            op_list.append(op)
+            op = SetOperation(type="SET_VALUE", ref=path, value=message)
+            ops.append(op)
 
-        multi_op = SetMultiOperation(type="SET", op_list=op_list)
+        multi_op = SetMultiOperation(type="SET", op_list=ops)
         return TransactionInput(
             operation=multi_op,
             timestamp=timestamp,

--- a/ainft/chat/messages.py
+++ b/ainft/chat/messages.py
@@ -95,7 +95,8 @@ class Messages:
                     str(msg.created_at),
                 ]
             )
-            content = truncate_text(msg.content, 200)
+            content = normalize_text(msg.content)
+            content = truncate_text(content, 200)
             content = content.encode("unicode-escape").decode("ASCII")
             message = {
                 "id": msg.id,

--- a/ainft/chat/threads.py
+++ b/ainft/chat/threads.py
@@ -40,15 +40,13 @@ class Threads:
 
         await self._validate(app_id, token_id, thread_id)
 
-        return await self._send_tx_for_store_thread(
-            **dict(
-                thread_id=thread_id,
-                app_id=app_id,
-                token_id=token_id,
-                address=user_addr,
-                metadata=metadata,
-            )
-        )
+        return await self._send_tx_for_store_thread(**dict(
+            thread_id=thread_id,
+            app_id=app_id,
+            token_id=token_id,
+            address=user_addr,
+            metadata=metadata,
+        ))
 
     async def _validate(self, app_id: str, token_id: str, thread_id: str):
         await validate_app(app_id, self._ain.db)

--- a/ainft/utils.py
+++ b/ainft/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 import re
 import uuid
+import unicodedata
 from typing import Any
 
 
@@ -33,6 +34,11 @@ def join_paths(paths: list) -> str:
 
 def now() -> float:
     return datetime.now().timestamp()
+
+
+def normalize_text(text: str) -> str:
+    outputs = unicodedata.normalize("NFKD", text)
+    return "".join([c for c in outputs if not unicodedata.combining(c)])
 
 
 def truncate_text(text: str, max_length: int) -> str:

--- a/ainft/utils.py
+++ b/ainft/utils.py
@@ -35,6 +35,14 @@ def now() -> float:
     return datetime.now().timestamp()
 
 
+def truncate_text(text: str, max_length: int) -> str:
+    if max_length <= 0:
+        raise ValueError("max_length must be greater than 0.")
+    if len(text) > max_length:
+        return text[: max_length - 3] + "..."
+    return text
+
+
 def validate_user_address(wallet: Wallet) -> str:
     user_addr = get_user_address(wallet)
     if user_addr is None:

--- a/tests/data.py
+++ b/tests/data.py
@@ -7,4 +7,7 @@ blockchain_url = "https://testnet-api.ainetwork.ai"
 chain_id = 0
 
 object_id = "0xB2710D23834d3ef4651dF66661da94C52df38612"
+app_id = "ainft721_0xb2710d23834d3ef4651df66661da94c52df38612"
 token_id = "1"
+
+thread_id = "15f576b9-2bba-446b-b416-5cff3687f5da"

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+
 from ainft.client import Ainft
 from ainft.types import Message
 
@@ -19,7 +20,7 @@ class TestMessages:
         messages = [
             Message(
                 id="1",
-                thread_id="15f576b9-2bba-446b-b416-5cff3687f5da",
+                thread_id=thread_id,
                 role="user",
                 content="What is your name?",
                 assistant_id=None,
@@ -27,7 +28,7 @@ class TestMessages:
             ),
             Message(
                 id="2",
-                thread_id="15f576b9-2bba-446b-b416-5cff3687f5da",
+                thread_id=thread_id,
                 role="assistant",
                 content="I am aina from ai network.",
                 assistant_id="asst_000000000000000000000001",
@@ -44,3 +45,29 @@ class TestMessages:
         assert re.match(tx_pattern, result.tx_hash) is not None
         assert result.result is not None
         assert len(result.messages) == 2
+
+    async def test_method_store_with_emojis(self):
+        message = Message(
+            id="3",
+            thread_id=thread_id,
+            role="user",
+            content="How are you today? 😊🌟🌈",
+            assistant_id=None,
+            created_at=1710748302,
+        )
+
+        result = await self.ainft.chat.messages.store(
+            messages=[message],
+            object_id=object_id,
+            token_id=token_id,
+        )
+        path = f"apps/{app_id}/tokens/{token_id}/ai/ainize_openai/history/{address}/threads/{thread_id}/messages/{message.created_at}"
+        escaped_message = await self.ainft._ain.db.ref(path).getValue()
+
+        assert re.match(tx_pattern, result.tx_hash) is not None
+        assert result.result is not None
+        assert len(result.messages) == 1
+        assert (
+            escaped_message["content"].encode("ASCII").decode("unicode-escape")
+            == message.content
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from ainft.utils import normalize_text, truncate_text
+
+
+class TestUtils:
+    def test_normalize_text(self):
+        assert normalize_text("é" * 10) == "e" * 10
+        assert normalize_text("ñ" * 10) == "n" * 10
+
+    def test_truncate_simple_text(self):
+        assert truncate_text("a" * 11, 10) == "a" * 7 + "..."
+
+    def test_truncate_korean_text(self):
+        assert truncate_text("한" * 11, 10) == "한" * 7 + "..."
+
+    def test_truncate_emoji_text(self):
+        assert truncate_text("😊" * 11, 10) == "😊" * 7 + "..."
+
+    def test_truncate_special_character_text(self):
+        assert truncate_text("€" * 11, 10) == "€" * 7 + "..."
+
+    def test_truncate_combined_character_text(self):
+        assert truncate_text("é" * 11, 10) == "ééée..."
+
+    def test_truncate_normalized_text(self):
+        assert truncate_text(normalize_text("é" * 11), 10) == "e" * 7 + "..."


### PR DESCRIPTION
## Summary
- not converting unicode results in an error during signature generation.
- so, store text with emojis using unicode escape.
  - "How are you today? 😊🌟🌈 "
  - => "How are you today? \\U0001f60a\\U0001f31f\\U0001f308"
- normalize text first and then truncate it.