### PR TITLE
Handle unicode combining characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A python version of [ainft-js](https://github.com/ainft-team/ainft-js).
 
 ## Installation
 
-```bash
+```sh
 pip install ainft-py
 ```
 
@@ -17,7 +17,7 @@ import os
 from ainft import Ainft
 
 ainft = Ainft(
-    private_key=os.environ.get("AINETWORK_PRIVATE_KEY"),
+    private_key=os.environ.get("AIN_PRIVATE_KEY"),
     api_url="https://ainft-api-dev.ainetwork.ai",
     blockchain_url="https://testnet-api.ainetwork.ai",
     chain_id=0,

--- a/ainft/chat/messages.py
+++ b/ainft/chat/messages.py
@@ -95,8 +95,7 @@ class Messages:
                     str(msg.created_at),
                 ]
             )
-            content = normalize_text(msg.content)
-            content = truncate_text(content, 200)
+            content = truncate_text(msg.content, 200)
             content = content.encode("unicode-escape").decode("ASCII")
             message = {
                 "id": msg.id,

--- a/ainft/utils.py
+++ b/ainft/utils.py
@@ -36,14 +36,11 @@ def now() -> float:
     return datetime.now().timestamp()
 
 
-def normalize_text(text: str) -> str:
-    outputs = unicodedata.normalize("NFKD", text)
-    return "".join([c for c in outputs if not unicodedata.combining(c)])
-
-
 def truncate_text(text: str, max_length: int) -> str:
     if max_length <= 0:
         raise ValueError("max_length must be greater than 0.")
+    text = text.strip()
+    text = unicodedata.normalize('NFC', text)
     if len(text) > max_length:
         return text[: max_length - 3] + "..."
     return text

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -51,7 +51,7 @@ class TestMessages:
             id="3",
             thread_id=thread_id,
             role="user",
-            content="How are you today? 😊🌟🌈",
+            content="How áre you today? 😊🌟🌈",
             assistant_id=None,
             created_at=1710748302,
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-from ainft.utils import normalize_text, truncate_text
+from ainft.utils import truncate_text
 
 
 class TestUtils:
-    def test_normalize_text(self):
-        assert normalize_text("é" * 10) == "e" * 10
-        assert normalize_text("ñ" * 10) == "n" * 10
-
     def test_truncate_simple_text(self):
         assert truncate_text("a" * 11, 10) == "a" * 7 + "..."
 
@@ -20,8 +16,5 @@ class TestUtils:
     def test_truncate_special_character_text(self):
         assert truncate_text("€" * 11, 10) == "€" * 7 + "..."
 
-    def test_truncate_combined_character_text(self):
-        assert truncate_text("é" * 11, 10) == "ééée..."
-
-    def test_truncate_normalized_text(self):
-        assert truncate_text(normalize_text("é" * 11), 10) == "e" * 7 + "..."
+    def test_truncate_combining_character_text(self):
+        assert truncate_text("é" * 11, 10) == "ééééééé..."


### PR DESCRIPTION
## Summary
- Normalize text using [NFC form](https://docs.python.org/3/library/unicodedata.html#unicodedata.normalize) when truncate. 
- NFC form: `e + ́  => é`